### PR TITLE
Fix usb ctrl in packet same size as endpoint

### DIFF
--- a/Library/StdDriver/src/usbd.c
+++ b/Library/StdDriver/src/usbd.c
@@ -49,6 +49,7 @@ static volatile uint32_t g_usbd_UsbAddr = 0;
 static volatile uint32_t g_usbd_UsbConfig = 0;
 static volatile uint32_t g_usbd_CtrlMaxPktSize = 8;
 static volatile uint32_t g_usbd_UsbAltInterface = 0;
+static volatile uint8_t  g_usbd_CtrlInZeroFlag = 0;
 /**
  * @endcond
  */
@@ -524,6 +525,10 @@ void USBD_PrepareCtrlIn(uint8_t *pu8Buf, uint32_t u32Size)
         // Data size <= MXPLD
         g_usbd_CtrlInPointer = 0;
         g_usbd_CtrlInSize = 0;
+        
+        if (u32Size == g_usbd_CtrlMaxPktSize)
+            g_usbd_CtrlInZeroFlag = 1;
+
         USBD_SET_DATA1(EP0);
         USBD_MemCopy((uint8_t *)USBD_BUF_BASE + USBD_GET_EP_BUF_ADDR(EP0), pu8Buf, u32Size);
         USBD_SET_PAYLOAD_LEN(EP0, u32Size);
@@ -542,8 +547,6 @@ void USBD_PrepareCtrlIn(uint8_t *pu8Buf, uint32_t u32Size)
   */
 void USBD_CtrlIn(void)
 {
-    static uint8_t u8ZeroFlag = 0;
-
     DBG_PRINTF("Ctrl In Ack. residue %d\n", g_usbd_CtrlInSize);
 
     if (g_usbd_CtrlInSize) {
@@ -560,7 +563,7 @@ void USBD_CtrlIn(void)
             USBD_SET_PAYLOAD_LEN(EP0, g_usbd_CtrlInSize);
 
             if (g_usbd_CtrlInSize == g_usbd_CtrlMaxPktSize)
-                u8ZeroFlag = 1;
+                g_usbd_CtrlInZeroFlag = 1;
 
             g_usbd_CtrlInPointer = 0;
             g_usbd_CtrlInSize = 0;
@@ -574,9 +577,9 @@ void USBD_CtrlIn(void)
         }
 
         /* For the case of data size is integral times maximum packet size */
-        if (u8ZeroFlag) {
+        if (g_usbd_CtrlInZeroFlag) {
             USBD_SET_PAYLOAD_LEN(EP0, 0);
-            u8ZeroFlag = 0;
+            g_usbd_CtrlInZeroFlag = 0;
         }
 
         DBG_PRINTF("Ctrl In done.\n");


### PR DESCRIPTION
This fixes an issue if a ctrl in packet has the same size as the endpoint max size. In my case the device didn't load in Windows if a HID Report Descriptor was exactly 64 bytes.