### PR TITLE
uninitialized pointer bug in SendChar; quell lots of GCC warnings

### DIFF
--- a/Library/StdDriver/src/adc.c
+++ b/Library/StdDriver/src/adc.c
@@ -59,6 +59,7 @@ void ADC_Open(ADC_T *adc,
   */
 void ADC_Close(ADC_T *adc)
 {
+    (void) adc;
     SYS->IPRST1 |= SYS_IPRST1_ADCRST_Msk;
     SYS->IPRST1 &= ~SYS_IPRST1_ADCRST_Msk;
     return;
@@ -125,6 +126,7 @@ void ADC_EnableTimerTrigger(ADC_T *adc,
                             uint32_t u32Source,
                             uint32_t u32Param)
 {
+    (void) u32Param;
     adc->ADCR &= ~(ADC_ADCR_TRGS_Msk | ADC_ADCR_TRGCOND_Msk | ADC_ADCR_TRGEN_Msk);
     adc->ADCR |= u32Source | ADC_ADCR_TRGEN_Msk;
     return;

--- a/Library/StdDriver/src/bpwm.c
+++ b/Library/StdDriver/src/bpwm.c
@@ -38,6 +38,9 @@ uint32_t BPWM_ConfigCaptureChannel(BPWM_T *bpwm, uint32_t u32ChannelNum, uint32_
     uint32_t u32NearestUnitTimeNsec;
     uint16_t u16Prescale = 1, u16CNR = 0xFFFF;
 
+    (void) u32ChannelNum;
+    (void) u32CaptureEdge;
+
     if (bpwm == BPWM0)
         u32Src = CLK->CLKSEL1 & CLK_CLKSEL1_BPWM0SEL_Msk;
     else//(bpwm == BPWM1)
@@ -66,7 +69,7 @@ uint32_t BPWM_ConfigCaptureChannel(BPWM_T *bpwm, uint32_t u32ChannelNum, uint32_
             if (u16Prescale == 0x1000) //limit to the maximum unit time(nano second)
                 break;
 
-            if (!((1000000 * (u16Prescale + 1) > (u32NearestUnitTimeNsec * u32PWMClockSrc))))
+            if (!((1000000UL * (u16Prescale + 1) > (u32NearestUnitTimeNsec * u32PWMClockSrc))))
                 break;
 
             continue;
@@ -182,6 +185,7 @@ uint32_t BPWM_ConfigOutputChannel(BPWM_T *bpwm, uint32_t u32ChannelNum, uint32_t
  */
 void BPWM_Start(BPWM_T *bpwm, uint32_t u32ChannelMask)
 {
+    (void) u32ChannelMask;
     (bpwm)->CNTEN = BPWM_CNTEN_CNTEN0_Msk;
 }
 
@@ -197,6 +201,7 @@ void BPWM_Start(BPWM_T *bpwm, uint32_t u32ChannelMask)
  */
 void BPWM_Stop(BPWM_T *bpwm, uint32_t u32ChannelMask)
 {
+    (void) u32ChannelMask;
     (bpwm)->PERIOD = 0;
 }
 
@@ -212,6 +217,7 @@ void BPWM_Stop(BPWM_T *bpwm, uint32_t u32ChannelMask)
  */
 void BPWM_ForceStop(BPWM_T *bpwm, uint32_t u32ChannelMask)
 {
+    (void) u32ChannelMask;
     (bpwm)->CNTEN &= ~BPWM_CNTEN_CNTEN0_Msk;
 }
 
@@ -279,6 +285,7 @@ void BPWM_DisableADCTrigger(BPWM_T *bpwm, uint32_t u32ChannelNum)
  */
 void BPWM_ClearADCTriggerFlag(BPWM_T *bpwm, uint32_t u32ChannelNum, uint32_t u32Condition)
 {
+    (void) u32Condition;
     (bpwm)->STATUS = (BPWM_STATUS_ADCTRG0_Msk << u32ChannelNum);
 }
 
@@ -501,6 +508,8 @@ uint32_t BPWM_GetDutyIntFlag(BPWM_T *bpwm, uint32_t u32ChannelNum)
  */
 void BPWM_EnablePeriodInt(BPWM_T *bpwm, uint32_t u32ChannelNum,  uint32_t u32IntPeriodType)
 {
+    (void) u32ChannelNum;
+    (void) u32IntPeriodType;
     (bpwm)->INTEN |= BPWM_INTEN_PIEN0_Msk;
 }
 
@@ -516,6 +525,7 @@ void BPWM_EnablePeriodInt(BPWM_T *bpwm, uint32_t u32ChannelNum,  uint32_t u32Int
  */
 void BPWM_DisablePeriodInt(BPWM_T *bpwm, uint32_t u32ChannelNum)
 {
+    (void) u32ChannelNum;
     (bpwm)->INTEN &= ~BPWM_INTEN_PIEN0_Msk;
 }
 
@@ -531,6 +541,7 @@ void BPWM_DisablePeriodInt(BPWM_T *bpwm, uint32_t u32ChannelNum)
  */
 void BPWM_ClearPeriodIntFlag(BPWM_T *bpwm, uint32_t u32ChannelNum)
 {
+    (void) u32ChannelNum;
     (bpwm)->INTSTS0 = BPWM_INTSTS0_PIF0_Msk;
 }
 
@@ -548,6 +559,7 @@ void BPWM_ClearPeriodIntFlag(BPWM_T *bpwm, uint32_t u32ChannelNum)
  */
 uint32_t BPWM_GetPeriodIntFlag(BPWM_T *bpwm, uint32_t u32ChannelNum)
 {
+    (void) u32ChannelNum;
     return (((bpwm)->INTSTS0 & BPWM_INTSTS0_PIF0_Msk) ? 1 : 0);
 }
 
@@ -563,6 +575,7 @@ uint32_t BPWM_GetPeriodIntFlag(BPWM_T *bpwm, uint32_t u32ChannelNum)
  */
 void BPWM_EnableZeroInt(BPWM_T *bpwm, uint32_t u32ChannelNum)
 {
+    (void) u32ChannelNum;
     (bpwm)->INTEN |= BPWM_INTEN_ZIEN0_Msk;
 }
 
@@ -578,6 +591,7 @@ void BPWM_EnableZeroInt(BPWM_T *bpwm, uint32_t u32ChannelNum)
  */
 void BPWM_DisableZeroInt(BPWM_T *bpwm, uint32_t u32ChannelNum)
 {
+    (void) u32ChannelNum;
     (bpwm)->INTEN &= ~BPWM_INTEN_ZIEN0_Msk;
 }
 
@@ -593,6 +607,7 @@ void BPWM_DisableZeroInt(BPWM_T *bpwm, uint32_t u32ChannelNum)
  */
 void BPWM_ClearZeroIntFlag(BPWM_T *bpwm, uint32_t u32ChannelNum)
 {
+    (void) u32ChannelNum;
     (bpwm)->INTSTS0 = BPWM_INTSTS0_ZIF0_Msk;
 }
 
@@ -610,6 +625,7 @@ void BPWM_ClearZeroIntFlag(BPWM_T *bpwm, uint32_t u32ChannelNum)
  */
 uint32_t BPWM_GetZeroIntFlag(BPWM_T *bpwm, uint32_t u32ChannelNum)
 {
+    (void) u32ChannelNum;
     return (((bpwm)->INTSTS0 & BPWM_INTSTS0_ZIF0_Msk) ? 1 : 0);
 }
 
@@ -665,6 +681,7 @@ void BPWM_DisableLoadMode(BPWM_T *bpwm, uint32_t u32ChannelNum, uint32_t u32Load
  */
 void BPWM_SetClockSource(BPWM_T *bpwm, uint32_t u32ChannelNum, uint32_t u32ClkSrcSel)
 {
+    (void) u32ChannelNum;
     (bpwm)->CLKSRC = (u32ClkSrcSel);
 }
 
@@ -682,6 +699,7 @@ void BPWM_SetClockSource(BPWM_T *bpwm, uint32_t u32ChannelNum, uint32_t u32ClkSr
  */
 uint32_t BPWM_GetWrapAroundFlag(BPWM_T *bpwm, uint32_t u32ChannelNum)
 {
+    (void) u32ChannelNum;
     return (((bpwm)->STATUS & BPWM_STATUS_CNTMAX0_Msk) ? 1 : 0);
 }
 
@@ -697,6 +715,7 @@ uint32_t BPWM_GetWrapAroundFlag(BPWM_T *bpwm, uint32_t u32ChannelNum)
  */
 void BPWM_ClearWrapAroundFlag(BPWM_T *bpwm, uint32_t u32ChannelNum)
 {
+    (void) u32ChannelNum;
     (bpwm)->STATUS = BPWM_STATUS_CNTMAX0_Msk;
 }
 

--- a/Library/StdDriver/src/fmc.c
+++ b/Library/StdDriver/src/fmc.c
@@ -257,7 +257,7 @@ uint32_t FMC_ReadDataFlashBaseAddr(void)
   */
 int32_t FMC_ReadConfig(uint32_t *u32Config, uint32_t u32Count)
 {
-    int32_t i;
+    uint32_t i;
 
     for (i = 0; i < u32Count; i++)
         u32Config[i] = FMC_Read(FMC_CONFIG_BASE + i * 4);
@@ -282,7 +282,7 @@ int32_t FMC_ReadConfig(uint32_t *u32Config, uint32_t u32Count)
   */
 int32_t FMC_WriteConfig(uint32_t *u32Config, uint32_t u32Count)
 {
-    int32_t i;
+    uint32_t i;
 
     for (i = 0; i < u32Count; i++)
     {

--- a/Library/StdDriver/src/pwm.c
+++ b/Library/StdDriver/src/pwm.c
@@ -38,6 +38,8 @@ uint32_t PWM_ConfigCaptureChannel(PWM_T *pwm, uint32_t u32ChannelNum, uint32_t u
     uint32_t u32NearestUnitTimeNsec;
     uint16_t u16Prescale = 1, u16CNR = 0xFFFF;
 
+    (void) u32CaptureEdge;
+
     if (pwm == PWM0)
         u32Src = CLK->CLKSEL1 & CLK_CLKSEL1_PWM0SEL_Msk;
     else//(pwm == PWM1)
@@ -66,7 +68,7 @@ uint32_t PWM_ConfigCaptureChannel(PWM_T *pwm, uint32_t u32ChannelNum, uint32_t u
             if (u16Prescale == 0x1000) //limit to the maximum unit time(nano second)
                 break;
 
-            if (!((1000000 * (u16Prescale + 1) > (u32NearestUnitTimeNsec * u32PWMClockSrc))))
+            if (!((1000000UL * (u16Prescale + 1) > (u32NearestUnitTimeNsec * u32PWMClockSrc))))
                 break;
 
             continue;
@@ -303,6 +305,7 @@ void PWM_DisableADCTrigger(PWM_T *pwm, uint32_t u32ChannelNum)
  */
 void PWM_ClearADCTriggerFlag(PWM_T *pwm, uint32_t u32ChannelNum, uint32_t u32Condition)
 {
+    (void) u32Condition;
     (pwm)->STATUS = (PWM_STATUS_ADCTRG0_Msk << u32ChannelNum);
 }
 
@@ -735,6 +738,7 @@ uint32_t PWM_GetFaultBrakeIntFlag(PWM_T *pwm, uint32_t u32BrakeSource)
  */
 void PWM_EnablePeriodInt(PWM_T *pwm, uint32_t u32ChannelNum,  uint32_t u32IntPeriodType)
 {
+    (void) u32IntPeriodType;
     (pwm)->INTEN0 |= (PWM_INTEN0_PIEN0_Msk << ((u32ChannelNum >> 1) << 1));
 }
 
@@ -858,7 +862,7 @@ uint32_t PWM_GetZeroIntFlag(PWM_T *pwm, uint32_t u32ChannelNum)
  */
 void PWM_SetClockSource(PWM_T *pwm, uint32_t u32ChannelNum, uint32_t u32ClkSrcSel)
 {
-    (pwm)->CLKSRC = (pwm)->CLKSRC & ~(PWM_CLKSRC_ECLKSRC0_Msk << ((u32ChannelNum >> 1) * PWM_CLKSRC_ECLKSRC2_Pos)) | \
+    (pwm)->CLKSRC = ((pwm)->CLKSRC & ~(PWM_CLKSRC_ECLKSRC0_Msk << ((u32ChannelNum >> 1) * PWM_CLKSRC_ECLKSRC2_Pos))) | \
                     (u32ClkSrcSel << ((u32ChannelNum >> 1) * PWM_CLKSRC_ECLKSRC2_Pos));
 }
 

--- a/Library/StdDriver/src/retarget.c
+++ b/Library/StdDriver/src/retarget.c
@@ -66,14 +66,14 @@ enum { r0, r1, r2, r3, r12, lr, pc, psr};
  */
 static void stackDump(uint32_t stack[])
 {
-    printf("r0  = 0x%x\n", stack[r0]);
-    printf("r1  = 0x%x\n", stack[r1]);
-    printf("r2  = 0x%x\n", stack[r2]);
-    printf("r3  = 0x%x\n", stack[r3]);
-    printf("r12 = 0x%x\n", stack[r12]);
-    printf("lr  = 0x%x\n", stack[lr]);
-    printf("pc  = 0x%x\n", stack[pc]);
-    printf("psr = 0x%x\n", stack[psr]);
+    printf("r0  = 0x%lx\n", stack[r0]);
+    printf("r1  = 0x%lx\n", stack[r1]);
+    printf("r2  = 0x%lx\n", stack[r2]);
+    printf("r3  = 0x%lx\n", stack[r3]);
+    printf("r12 = 0x%lx\n", stack[r12]);
+    printf("lr  = 0x%lx\n", stack[lr]);
+    printf("pc  = 0x%lx\n", stack[pc]);
+    printf("psr = 0x%lx\n", stack[psr]);
 }
 
 /**
@@ -391,7 +391,6 @@ __attribute__((weak))
 void ProcessHardFault(uint32_t lr, uint32_t msp, uint32_t psp)
 {
     uint32_t *sp;
-    uint32_t inst;
 
     /* Check the used stack */
 
@@ -602,9 +601,9 @@ void SendChar(int ch)
 #else
 
 #if defined ( __GNUC__ )
-    char *ch0;
-    *ch0 = (char)ch;
-    _write(0, ch0, 1);
+    char ch0;
+    ch0 = (char)ch;
+    _write(0, &ch0, 1);
 #else
     SendChar_ToUART(ch);
 #endif /* ( __GNUC__ ) */
@@ -728,6 +727,7 @@ void _ttywrch(int ch)
 
 int fputc(int ch, FILE *stream)
 {
+    (void) stream;
     SendChar(ch);
     return ch;
 }
@@ -739,6 +739,8 @@ int fputc(int ch, FILE *stream)
 int _write(int fd, char *ptr, int len)
 {
     int i = len;
+
+    (void) fd;
 
     while (i--)
     {
@@ -760,6 +762,9 @@ int _write(int fd, char *ptr, int len)
 
 int _read(int fd, char *ptr, int len)
 {
+    (void) fd;
+    (void) len;
+
     while ((DEBUG_PORT->FIFOSTS & UART_FIFOSTS_RXEMPTY_Msk) != 0);
 
     *ptr = DEBUG_PORT->DAT;

--- a/Library/StdDriver/src/usbd.c
+++ b/Library/StdDriver/src/usbd.c
@@ -464,7 +464,7 @@ void USBD_StandardRequest(void)
         {
             if (g_USBD_au8SetupPacket[2] == FEATURE_ENDPOINT_HALT)
             {
-                int32_t epNum, i;
+                uint32_t epNum, i;
 
                 /* EP number stall is not allow to be clear in MSC class "Error Recovery Test".
                    a flag: g_u32EpStallLock is added to support it */

--- a/Library/StdDriver/src/usci_spi.c
+++ b/Library/StdDriver/src/usci_spi.c
@@ -134,6 +134,7 @@ void USPI_DisableAutoSS(USPI_T *uspi)
   */
 void USPI_EnableAutoSS(USPI_T *uspi, uint32_t u32SSPinMask, uint32_t u32ActiveLevel)
 {
+    (void) u32SSPinMask;
     uspi->LINECTL = (uspi->LINECTL & ~USPI_LINECTL_CTLOINV_Msk) | u32ActiveLevel;
     uspi->PROTCTL |= USPI_PROTCTL_AUTOSS_Msk;
 }


### PR DESCRIPTION
There is a genuine bug in /Library/StdDriver/src/retarget.c in SendChar() when defined ( __GNUC__ ).  Without the modification, an uninitialized pointer is de-referenced and written to.

The rest of changes are due to modern versions of gcc that have been configured to treat warnings as errors.
